### PR TITLE
VS Code 1.1 uses a different preference for disabling syntax validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Follow the [instructions](https://code.visualstudio.com/docs/editor/extension-ga
 
 ## Known Issues
 
-* You should set workspace preference to disable default syntax validation from Visual Studio Code: `"javascript.validate.syntaxValidation": false`.
+* You should set workspace preference to disable default syntax validation from Visual Studio Code: `"javascript.validate.enable": false`.
 
 ## About
 


### PR DESCRIPTION
According to VS Code's [official documentation] (https://code.visualstudio.com/Docs/languages/javascript#_disable-syntax-validation-when-using-non-es6-constructs), the preference used for disabling syntax validation is now `javascript.validate.enable: false`. However, the documentation for this plugin states that the preference is `javascript.validate.syntaxValidation`. I might be mistaken, so please double-check.